### PR TITLE
Update the way flags work

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const fluent = ({ methods, executors, flags, defaults }) => () => {
   for (const [flag, cb] of Object.entries(flags)) {
     Object.defineProperty(res, flag, {
       get() {
-        cb(ctx)
+        Object.assign(ctx, cb(ctx))
         return res
       }
     })


### PR DESCRIPTION
it doesn't mutate context `ctx` now, it should return updated object `ctx`